### PR TITLE
Add tncattach/rnodeconf to use RNodes as packet TNCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,19 @@ waterfalls will start running again.
 
 ## Building a bootable USB flash drive
 
-On an Ubuntu system:
+On a Debian-based system:
+
+* Install the dependencies: `sudo apt install qemu-system-x86 ovmf`
+
+On an Arch-based system:
+
+* Install the dependencies: `sudo pacman -S qemu-full edk2-ovmf`
+
+Additional steps:
 
 * Download https://releases.ubuntu.com/noble/ubuntu-24.04.2-live-server-amd64.iso
   and place it in `~/Downloads/`
-* Install the dependencies: `sudo apt install qemu-system-x86 ovmf`
-* Generate the live USB images: `liveusb/create.sh`
+* Generate the live USB images: `./liveusb/create.sh`
 * At the prompt, enter your password to allow the Ubuntu ISO to be mounted
 * Write an image to a flash drive (16 GB or larger): `sudo dd if=liveusb/contest-sdr-uefi.img of=/dev/sdb bs=4M conv=fsync`
 
@@ -63,7 +70,7 @@ For old systems that don't support UEFI, the `contest-sdr-bios.img` image can be
 
 ## License
 
-Copyright 2015-2024 Clayton Smith
+Copyright 2015-2025 Clayton Smith
 
 This file is part of contest-sdr
 

--- a/liveusb/trust_desktop.sh
+++ b/liveusb/trust_desktop.sh
@@ -1,9 +1,8 @@
 #!/bin/sh
 
-for f in ~/Desktop/*.desktop
-do
-  chmod +x "$f"
-  gio set -t string "$f" metadata::xfce-exe-checksum "$(sha256sum "$f" | awk '{print $1}')"
+for f in ~/Desktop/*.desktop; do
+    chmod +x "$f"
+    gio set -t string "$f" metadata::xfce-exe-checksum "$(sha256sum "$f" | awk '{print $1}')"
 done
 
 rm ~/.config/autostart/trust_desktop.desktop ~/trust_desktop.sh

--- a/liveusb/user-data
+++ b/liveusb/user-data
@@ -19,6 +19,8 @@ autoinstall:
     - libiio-dev
     - libad9361-dev
     - cmake
+    - build-essential
+    - python3-pip
   late-commands:
     - curtin in-target --target=/target -- apt-get -y purge gdm3
     - echo [SeatDefaults] >> /target/etc/lightdm/lightdm.conf.d/login.conf
@@ -43,3 +45,7 @@ autoinstall:
     - curtin in-target --target=/target -- cmake -DCMAKE_INSTALL_PREFIX=/usr -S /opt/SoapyPlutoSDR -B /opt/SoapyPlutoSDR/build
     - curtin in-target --target=/target -- cmake --build /opt/SoapyPlutoSDR/build
     - curtin in-target --target=/target -- cmake --install /opt/SoapyPlutoSDR/build
+    - git clone https://github.com/markqvist/tncattach.git /target/opt/tncattach
+    - curtin in-target --target=/target -- make --directory /opt/tncattach tncattach
+    - curtin in-target --target=/target -- make --directory /opt/tncattach install
+    - curtin in-target --target=/target -- python3 -m pip install --break-system-packages rns


### PR DESCRIPTION
@argilo 

New things:
- added "tncattach" tool and man-page
- added "rnodeconf" tool (put RNode devices into TNC mode, config freq, etc.)
- everything builds on Arch Linux workstations now (please retest Ubuntu)

![Screenshot_from_2025-04-14_15-20-14](https://github.com/user-attachments/assets/b0bf9e97-8458-4d9f-bec2-7177b58253d0)
![Screenshot_from_2025-04-14_16-44-33](https://github.com/user-attachments/assets/41ea6ea9-920c-4fb7-bdb7-9f32e77b4bf2)

NOTE:  "tncattach" was installed from source rather than a pre-compiled release file from GitHub due to the convenience of having the man-page be included rather than a README.html file.

Instructions for using this are at:
- https://unsigned.io/tncattach
- https://unsigned.io/guides/2018_07_01_using-rnode-as-a-lora-based-wireless-nic.html
- https://unsigned.io/guides/2020_05_27_ethernet-and-ip-over-packet-radio-tncs.html
- https://liamcottle.github.io/rnode-flasher  to help loading RNode Firmware on devices